### PR TITLE
fix: access token available term

### DIFF
--- a/src/main/java/finity/fini/config/security/jwt/JwtUtil.java
+++ b/src/main/java/finity/fini/config/security/jwt/JwtUtil.java
@@ -15,10 +15,14 @@ import java.util.Date;
 public class JwtUtil {
 
     private final Key secretKey;
-    private final long validityInMilliseconds = 3600000; // 1시간
+    private final long validityInMilliseconds;
 
-    public JwtUtil(@Value("${jwt.secret}") String secret) {
+    public JwtUtil(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-validity-in-seconds}") long validityInSeconds)
+    {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.validityInMilliseconds = validityInSeconds * 1000;
     }
 
     // 토큰 생성
@@ -46,7 +50,6 @@ public class JwtUtil {
             Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
             return true;
         } catch (Exception e) {
-            // MalformedJwtException, ExpiredJwtException 등
             return false;
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,7 @@ spring:
         default_batch_fetch_size: 1000
 jwt:
   secret: ${JWT_SECRET}
+  access-token-validity-in-seconds: 5184000
 fss:
   api:
     key: ${FSS_API_KEY}


### PR DESCRIPTION
## 📌 Summary

access token 유효기간을 임시로 늘렸습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 인증 토큰의 만료 시간을 설정 파일을 통해 동적으로 구성할 수 있도록 개선되었습니다. 기본값은 5,184,000초(약 60일)로 설정되어 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->